### PR TITLE
Command error upon running the minimal example on Sockeye

### DIFF
--- a/error.md
+++ b/error.md
@@ -1,8 +1,11 @@
-```bash
+```
+Warning: command open returned non-zero code (1). Output so far:
+Couldn't get a file descriptor referring to the console
+
 N E X T F L O W  ~  version 18.10.1
-Launching `minimal.nf` [curious_boyd] - revision: 248b7b09fe
+Launching `minimal.nf` [boring_wing] - revision: 248b7b09fe
 [warm up] executor > local
-[a1/1ccda3] Submitted process > myPreprocessor
+[81/f6af66] Submitted process > myPreprocessor
 ERROR ~ Error executing process > 'myPreprocessor'
 
 Caused by:
@@ -26,7 +29,7 @@ Command error:
   /usr/bin/env: Rscript: No such file or directory
 
 Work dir:
-  /scratch/st-singha53-1/tliang19/work_dir/tmp/nextflow-notes-1/work/a1/1ccda30f9d7e89a39a2536558544f2
+  /scratch/st-singha53-1/tliang19/work_dir/tmp/nextflow-notes-1/work/81/f6af66d64089d9ae068740166cb5c0
 
 Tip: view the complete command output by changing to the process work dir and entering the command `cat .command.out`
 

--- a/error.md
+++ b/error.md
@@ -1,0 +1,34 @@
+```bash
+N E X T F L O W  ~  version 18.10.1
+Launching `minimal.nf` [curious_boyd] - revision: 248b7b09fe
+[warm up] executor > local
+[a1/1ccda3] Submitted process > myPreprocessor
+ERROR ~ Error executing process > 'myPreprocessor'
+
+Caused by:
+  Process `myPreprocessor` terminated with an error exit status (127)
+
+Command executed:
+
+  #!/usr/bin/env Rscript
+  
+  data("iris")
+  # [ some computationally expensive preprocessing can be added here ]
+  write.csv(iris, "output.csv")
+
+Command exit status:
+  127
+
+Command output:
+  (empty)
+
+Command error:
+  /usr/bin/env: Rscript: No such file or directory
+
+Work dir:
+  /scratch/st-singha53-1/tliang19/work_dir/tmp/nextflow-notes-1/work/a1/1ccda30f9d7e89a39a2536558544f2
+
+Tip: view the complete command output by changing to the process work dir and entering the command `cat .command.out`
+
+ -- Check '.nextflow.log' file for details
+```


### PR DESCRIPTION
Hello, I found this repository online and thought it could be helpful for introducing more into Nextflow. So I followed your steps in the [README.md](https://github.com/UBC-Stat-ML/nextflow-notes/blob/master/README.md), i.e. installing a sdkman and uses it to download java 11 (see blow):
![image](https://user-images.githubusercontent.com/83138402/215624743-eec96a16-8258-439a-8a87-eeac93458ad1.png)

However, I don't think this should be the issue of running the minimal example pipeline, below is a snapshot of the bug, where I also put it in a [markdown file](https://github.com/tonyliang19/nextflow-notes-1/blob/bug-minimal-run/error.md) inside the PR. Is there anything that I have missed for setting up the binary exe of `Rscript`?  Thanks!

![image](https://user-images.githubusercontent.com/83138402/215625082-e5418cc8-aef6-4837-a6b7-f729d40c7651.png)

